### PR TITLE
fix haddock markup in Language/JavaScript/Parser/Token.hs

### DIFF
--- a/src/Language/JavaScript/Parser/Token.hs
+++ b/src/Language/JavaScript/Parser/Token.hs
@@ -13,8 +13,9 @@
 -----------------------------------------------------------------------------
 
 module Language.JavaScript.Parser.Token
-    -- * The tokens
-    ( Token (..)
+    (
+      -- * The tokens
+      Token (..)
     , CommentAnnotation (..)
     -- * String conversion
     , debugTokenString


### PR DESCRIPTION
haddock failed as:
> src/Language/JavaScript/Parser/Token.hs:16:5:
>     parse error on input ‘-- * The tokens’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>