### PR TITLE
Updating alex dependency for ghc 7.10 to get the Applicative instances

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -37,10 +37,13 @@ Library
                    , blaze-builder    >= 0.2
                    , bytestring       >= 0.9.1
                    , utf8-string      >= 0.3.7 && < 2
-  if impl(ghc >= 7.8)
-    build-tools:       happy >= 1.19, alex >= 3.1
+  if impl(ghc >= 7.10)
+    build-tools:       happy >= 1.19, alex >= 3.1.4
   else
-    build-tools:       happy >= 1.18.5, alex >= 3.0.5
+    if impl(ghc >= 7.8)
+      build-tools:       happy >= 1.19, alex >= 3.1
+    else
+      build-tools:       happy >= 1.18.5, alex >= 3.0.5
   hs-source-dirs: src
   Exposed-modules:     Language.JavaScript.Parser
                        Language.JavaScript.Parser.Parser


### PR DESCRIPTION
I've tried to compile ```language-javascript``` with ghc 7.10 and cabal 1.22.2.0 and got this error:
```
templates/wrappers.hs:173:10:
    No instance for (Applicative Alex)
      arising from the superclasses of an instance declaration 
    In the instance declaration for ‘Monad Alex’
```
Alex only got the Applicative instances in 3.1.4 and the required version was >= 3.1 for it (given that ghc >= 7.8). I've updated the dependency for 7.10 only. It looks a bit ugly but I don't have a 7.8 at hand to test whether it works with it or not(tests pass with 7.10 btw).