### PR TITLE
Add a Traversals module

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -52,6 +52,7 @@ Library
                        Language.JavaScript.Parser.AST
                        Language.JavaScript.Pretty.Printer
                        Language.JavaScript.Parser.SrcLocation
+                       Language.JavaScript.Parser.Traversals
   Other-modules:       Language.JavaScript.Parser.LexerUtils
                        Language.JavaScript.Parser.ParseError
                        Language.JavaScript.Parser.ParserMonad

--- a/runtests.hs
+++ b/runtests.hs
@@ -775,11 +775,14 @@ traversalsSuite = testGroup "traversals"
 
   , group "warnUnnamedFns" warnUnnamedFns $
       [ ("function foo() { }\n foo()", return)
-      , ("function() { }\n foo()",   \ast -> tell ["Unnamed function at TokenPn 0 1 1"] >> return ast)
-      , ("\nfunction() { }\n foo()", \ast -> tell ["Unnamed function at TokenPn 1 2 1"] >> return ast)
+      , ("function() { }\n foo()",   positions ["0 1 1"])
+      , ("\nfunction() { }\n foo()", positions ["1 2 1"])
+      , ("(function() { \nreturn function()\n { return 3\n  }\n}\n)()", positions ["22 2 8", "1 1 2"])
       ]
   ]
   where
+  positions ps ast = tell (map ("Unnamed function at TokenPn " ++) ps) >> return ast
+
   group :: (Applicative m, Monad m, Show (m JSNode), Eq (m JSNode)) =>
            String -> (JSNode -> m JSNode) -> [(String, JSNode -> m JSNode)] -> Test
   group name f testData =

--- a/runtests.hs
+++ b/runtests.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE ViewPatterns #-}
 
 import Language.JavaScript.Parser
 import Language.JavaScript.Parser.Grammar5
 import Language.JavaScript.Parser.Lexer
 import Language.JavaScript.Parser.Parser
+import Language.JavaScript.Parser.Traversals
 
+import Control.Applicative (Applicative(..))
+import Control.Monad (ap, liftM)
 import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
+import Data.String (fromString)
 import Test.Framework (defaultMain, testGroup, Test)
 import Test.Framework.Providers.HUnit
 import Test.HUnit hiding (Test)
@@ -16,6 +22,7 @@ main = defaultMain
     , parserSuite
     -- ++AZ++temporary++ , commentSuite
     , commentPrintSuite
+    , traversalsSuite
     , pendingSuite
     ]
 
@@ -720,6 +727,67 @@ commentPrintSuite = testGroup "Comments"
     , testCase "comment-only" (testRoundTrip "// comment\n\n")
     , testCase "empty-src" (testRoundTrip "")
     ]
+
+-- ---------------------------------------------------------------------
+-- Traversals
+
+guardThrowLiteral :: JSNode -> Maybe JSNode
+guardThrowLiteral n = case unpackNode n of
+  JSThrow _ (unpackNode -> JSExpression ((unpackNode -> JSStringLiteral _ _):_)) ->
+    Nothing
+  _ ->
+    return n
+
+-- | A basic version of Writer, including a Show instance (transformers doesn't)
+data Log a = Log [String] a deriving (Eq, Show)
+
+instance Functor Log where
+  fmap = liftM
+
+instance Applicative Log where
+  pure = return
+  (<*>) = ap
+
+instance Monad Log where
+  return = Log []
+  (Log ls x) >>= f =
+    let Log ls' y = f x
+    in  Log (ls ++ ls') y
+
+tell :: [String] -> Log ()
+tell x = Log x ()
+
+warnUnnamedFns :: JSNode -> Log JSNode
+warnUnnamedFns n = case unpackNode n of
+  JSFunctionExpression (NT _ pos _) [] _ _ _ _ -> do
+    tell ["Unnamed function at " ++ show pos]
+    return n
+  _ ->
+    return n
+
+traversalsSuite :: Test
+traversalsSuite = testGroup "traversals"
+  [ group "guardThrowLiteral" guardThrowLiteral $
+      [ ("function foo() { }\n foo()", Just)
+      , ("function foo() { throw \"hi\" }\n foo()", const Nothing)
+      , ("function foo() { throw new Error(\"hi\") }\n foo()", Just)
+      ]
+
+  , group "warnUnnamedFns" warnUnnamedFns $
+      [ ("function foo() { }\n foo()", return)
+      , ("function() { }\n foo()",   \ast -> tell ["Unnamed function at TokenPn 0 1 1"] >> return ast)
+      , ("\nfunction() { }\n foo()", \ast -> tell ["Unnamed function at TokenPn 1 2 1"] >> return ast)
+      ]
+  ]
+  where
+  group :: (Applicative m, Monad m, Show (m JSNode), Eq (m JSNode)) =>
+           String -> (JSNode -> m JSNode) -> [(String, JSNode -> m JSNode)] -> Test
+  group name f testData =
+    testGroup name $ map (go f) testData
+    where
+    go f (source, expectedOf) = testCase (fromString (show source)) $ do
+      ast <- either fail return $ parse source "src"
+      expectedOf ast @=? everywhereOnJSNodesM f ast
 
 -- ---------------------------------------------------------------------
 -- Test utilities

--- a/src/Language/JavaScript/Parser/Traversals.hs
+++ b/src/Language/JavaScript/Parser/Traversals.hs
@@ -1,5 +1,9 @@
 
-module Language.JavaScript.Parser.Traversals where
+module Language.JavaScript.Parser.Traversals
+  ( innerNode
+  , unpackNode
+  , everywhereOnJSNodesM
+  ) where
 
 import Control.Applicative
 import Control.Monad
@@ -10,6 +14,11 @@ innerNode :: Applicative f => (Node -> f Node) -> JSNode -> f JSNode
 innerNode f n = case n of
   NN n'          -> NN <$> f n'
   NT n' pos anns -> NT <$> f n' <*> pure pos <*> pure anns
+
+unpackNode :: JSNode -> Node
+unpackNode n = case n of
+  NN n'     -> n'
+  NT n' _ _ -> n'
 
 everywhereOnJSNodesM :: (Applicative m, Monad m) => (JSNode -> m JSNode) -> JSNode -> m JSNode
 everywhereOnJSNodesM f = go

--- a/src/Language/JavaScript/Parser/Traversals.hs
+++ b/src/Language/JavaScript/Parser/Traversals.hs
@@ -1,0 +1,110 @@
+
+module Language.JavaScript.Parser.Traversals where
+
+import Control.Applicative
+import Control.Monad
+
+import Language.JavaScript.Parser.AST
+
+innerNode :: Applicative f => (Node -> f Node) -> JSNode -> f JSNode
+innerNode f n = case n of
+  NN n'          -> NN <$> f n'
+  NT n' pos anns -> NT <$> f n' <*> pure pos <*> pure anns
+
+everywhereOnJSNodesM :: (Applicative m, Monad m) => (JSNode -> m JSNode) -> JSNode -> m JSNode
+everywhereOnJSNodesM f = go
+  where
+  go = innerNode go' >=> f
+  go_ = mapM go
+
+  go' node = case node of
+    JSIdentifier{}    -> return node
+    JSDecimal{}       -> return node
+    JSLiteral{}       -> return node
+    JSHexInteger{}    -> return node
+    JSOctal{}         -> return node
+    JSStringLiteral{} -> return node
+    JSRegEx{}         -> return node
+
+    JSArguments lb args rb ->
+      JSArguments <$> go lb <*> go_ args <*> go rb
+    JSArrayLiteral lb contents rb ->
+      JSArrayLiteral <$> go lb <*> go_ contents <*> go rb
+    JSBlock lb stmts rb ->
+      JSBlock <$> go_ lb <*> go_ stmts <*> go_ rb
+    JSBreak break_ ids autosemi ->
+      JSBreak <$> go break_ <*> go_ ids <*> go autosemi
+    JSCallExpression ty opens contents closes ->
+      JSCallExpression ty <$> go_ opens <*> go_ contents <*> go_ closes
+    JSCase case_ expr colon stmts ->
+      JSCase <$> go case_ <*> go expr <*> go colon <*> go_ stmts
+    JSCatch lb ident if_ exprs rb block ->
+      JSCatch <$> go lb <*> go ident <*> go if_ <*> go_ exprs <*> go rb <*> go block
+    JSContinue cont ids autosemi ->
+      JSContinue <$> go cont <*> go_ ids <*> go autosemi
+    JSDefault def colon stmts ->
+      JSDefault <$> go def <*> go colon <*> go_ stmts
+    JSDoWhile do_ stmt while lb exprs rb autosemi ->
+      JSDoWhile <$> go do_ <*> go stmt <*> go while <*> go lb <*> go exprs <*> go rb <*> go autosemi
+    JSElision comma ->
+      JSElision <$> go comma
+    JSExpression exprs ->
+      JSExpression <$> go_ exprs
+    JSExpressionBinary what lhs op rhs ->
+      JSExpressionBinary what <$> go_ lhs <*> go op <*> go_ rhs
+    JSExpressionParen lb expr rb ->
+      JSExpressionParen <$> go lb <*> go expr <*> go rb
+    JSExpressionPostfix ty exprs op ->
+      JSExpressionPostfix ty <$> go_ exprs <*> go op
+    JSExpressionTernary cond qmark ifTrue colon ifFalse ->
+      JSExpressionTernary <$> go_ cond <*> go qmark <*> go_ ifTrue <*> go colon <*> go_ ifFalse
+    JSFinally finally block ->
+      JSFinally <$> go finally <*> go block
+    JSFor for lb es1 s1 es2 s2 es3 rb stmt ->
+      JSFor <$> go for <*> go lb <*> go_ es1 <*> go s1 <*> go_ es2 <*> go s2 <*> go_ es3 <*> go rb <*> go stmt 
+    JSForIn for lb exprs1 in_ expr2 rb stmts ->
+      JSForIn <$> go for <*> go lb <*> go_ exprs1 <*> go in_ <*> go expr2 <*> go rb <*> go stmts
+    JSForVar for lb var vardecl s1 es2 s2 es3 rb stmt ->
+      JSForVar <$> go for <*> go lb <*> go var <*> go_ vardecl <*> go s1 <*> go_ es2 <*> go s2 <*> go_ es3 <*> go rb <*> go stmt 
+    JSForVarIn for lb var vardecl in_ expr2 rb stmts ->
+      JSForVarIn <$> go for <*> go lb <*> go var <*> go vardecl <*> go in_ <*> go expr2 <*> go rb <*> go stmts
+    JSFunction fn name lb params rb block ->
+      JSFunction <$> go fn <*> go name <*> go lb <*> go_ params <*> go rb <*> go block
+    JSFunctionExpression fn names lb params rb block ->
+      JSFunctionExpression <$> go fn <*> go_ names <*> go lb <*> go_ params <*> go rb <*> go block
+    JSIf if_ lb cond rb thens elses ->
+      JSIf <$> go if_ <*> go lb <*> go cond <*> go rb <*> go_ thens <*> go_ elses
+    JSLabelled id_ colon stmt ->
+      JSLabelled <$> go id_ <*> go colon <*> go stmt
+    JSMemberDot firsts dot name ->
+      JSMemberDot <$> go_ firsts <*> go dot <*> go name
+    JSMemberSquare firsts lb expr rb ->
+      JSMemberSquare <$> go_ firsts <*> go lb <*> go expr <*> go rb
+    JSObjectLiteral lb props rb ->
+      JSObjectLiteral <$> go lb <*> go_ props <*> go rb
+    JSOperator opnode ->
+      JSOperator <$> go opnode
+    JSPropertyAccessor getset name lb params rb block ->
+      JSPropertyAccessor <$> go getset <*> go name <*> go lb <*> go_ params <*> go rb <*> go block
+    JSPropertyNameandValue name colon value ->
+      JSPropertyNameandValue <$> go name <*> go colon <*> go_ value
+    JSReturn return_ exprs autosemi ->
+      JSReturn <$> go return_ <*> go_ exprs <*> go autosemi
+    JSSourceElementsTop elems ->
+      JSSourceElementsTop <$> go_ elems
+    JSSwitch switch lb expr rb case_ ->
+      JSSwitch <$> go switch <*> go lb <*> go expr <*> go rb <*> go case_
+    JSThrow throw expr ->
+      JSThrow <$> go throw <*> go expr
+    JSTry try block rest ->
+      JSTry <$> go try <*> go block <*> go_ rest
+    JSUnary ty op ->
+      JSUnary ty <$> go op
+    JSVarDecl ident inits ->
+      JSVarDecl <$> go ident <*> go_ inits
+    JSVariables varconst decls autosemi ->
+      JSVariables <$> go varconst <*> go_ decls <*> go autosemi
+    JSWhile while lb expr rb stmt ->
+      JSWhile <$> go while <*> go lb <*> go expr <*> go rb <*> go stmt
+    JSWith with lb expr rb stmts ->
+      JSWith <$> go with <*> go lb <*> go expr <*> go rb <*> go_ stmts


### PR DESCRIPTION
The most important part of this pull request is the new function `everywhereOnJSNodesM`, which allows you to apply a function `JSNode -> m JSNode` to a `JSNode` *and also* to every `JSNode` within it, using some monad m.

There are a large number of potential uses for this. Two examples (which I also used as tests):

* Take `f :: JSNode -> Maybe JSNode`, which returns `Nothing` when the `JSNode` argument is a throw expression which throws a string literal; in all other cases, `f` is equivalent to `Just`. Then, `everywhereOnJSNodesM f` will be equivalent to `Just` iff the given AST contains no throw statements throwing string literals.
* Take `g :: JSNode -> Writer [String] JSNode`, which logs a message with the node's position iff the node is an unnamed function expression, and then returns the node. Then `everywhereOnJSNodesM g` will give you a list of all the unnamed function expressions in an AST.

Our actual use case was for testing the code in https://github.com/purescript/purescript/pull/1266; we wanted to ensure that the code that the PureScript compiler uses escape sequences in string literals for all characters which are not printable ASCII.