### PR TITLE
Fix some string escaping issues

### DIFF
--- a/Tests/Lexer.hs
+++ b/Tests/Lexer.hs
@@ -32,6 +32,8 @@ testLexer = describe "Lexer:" $ do
         testLex "'\\\\'"    `shouldBe` "[StringToken '\\\\']"
         testLex "'\\0'"     `shouldBe` "[StringToken '\\0']"
         testLex "'\\12'"    `shouldBe` "[StringToken '\\12']"
+        testLex "'\\s'"      `shouldBe` "[StringToken '\\s']"
+        testLex "'\\-'"      `shouldBe` "[StringToken '\\-']"
 
     it "strings with escaped quotes" $ do
         testLex "'\"'"      `shouldBe` "[StringToken '\"']"

--- a/src/Language/JavaScript/Parser/Lexer.x
+++ b/src/Language/JavaScript/Parser/Lexer.x
@@ -65,8 +65,8 @@ $not_eol_char = ~$eol_char -- anything but an end of line character
 $string_chars = [^ \n \r ' \" \\]
 
 -- See e.g. http://es5.github.io/x7.html#x7.8.4 (Table 4)
-@sq_escapes = \\ ( \\ | ' | \" | b | f | n | r | t | v | 0 | x )
-@dq_escapes = \\ ( \\ | ' | \" | b | f | n | r | t | v | 0 | x )
+@sq_escapes = \\ ( \\ | ' | \" | \s | \- | b | f | n | r | t | v | 0 | x )
+@dq_escapes = \\ ( \\ | ' | \" | \s | \- | b | f | n | r | t | v | 0 | x )
 
 @unicode_escape = \\ u $hex_digit{4}
 


### PR DESCRIPTION
Hi:

I was trying to use a markdown editor I found some lexing problems with \s and \- in some regex, this pull request fixes this problems and also adds two new test cases.

I have a doubt if my changes are in the correct place in Lexer.x or not.

The javascript that gives lexing problems is [here](https://raw.githubusercontent.com/NextStepWebs/simplemde-markdown-editor/master/debug/simplemde.js).

Best regards.