### PR TITLE
Fix the build with GHC 8.4.1

### DIFF
--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -36,6 +36,9 @@ Library
                    , bytestring       >= 0.9.1
                    , text             >= 1.2
                    , utf8-string      >= 0.3.7 && < 2
+  if !impl(ghc>=8.0)
+    build-depends:   semigroups       >= 0.16.1
+
   if impl(ghc >= 7.10)
     build-tools:       happy >= 1.19, alex >= 3.1.4
   else

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -10,7 +10,8 @@ module Language.JavaScript.Pretty.Printer
 
 import Blaze.ByteString.Builder (Builder, toLazyByteString)
 import Data.List
-import Data.Monoid (mappend, mempty)
+import Data.Monoid (mempty)
+import Data.Semigroup ((<>))
 import Data.Text.Lazy (Text)
 import Language.JavaScript.Parser.AST
 import Language.JavaScript.Parser.SrcLocation
@@ -26,9 +27,6 @@ data PosAccum = PosAccum (Int, Int) Builder
 
 -- ---------------------------------------------------------------------
 -- Pretty printer stuff via blaze-builder
-
-(<>) :: Builder -> Builder -> Builder
-(<>) = mappend
 
 str :: String -> Builder
 str = BS.fromString


### PR DESCRIPTION
The `(<>)` function defined locally in `Language.JavaScript.Pretty.Printer` clashes with `(Data.Semigroup.<>)`, which is exported by the `Prelude` in `base-4.11` (GHC 8.4). A simple solution is to simply use `(Data.Semigroup.<>)` instead, since its use is entirely internal to this module.