### PR TITLE
Support GHC 8.4.1 (0.5 branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 /dist/*
+/dist-newstyle
 /parse.txt
 /src/Language/JavaScript/Parser/Lexer.info
 /unicode/uc-ll.htm
@@ -14,3 +15,4 @@
 /unicode/uc-nl.htm
 /unicode/uc-pc.htm
 cabal.sandbox.config
+.ghc.environment.*

--- a/language-javascript.cabal
+++ b/language-javascript.cabal
@@ -6,6 +6,7 @@ Description:         Parses Javascript into an Abstract Syntax Tree (AST).  Init
                      Note: Version 0.5.0 breaks compatibility with prior versions, the AST has been reworked to allow
                      round trip processing of JavaScript.
 Homepage:            https://github.com/erikd/language-javascript
+Bug-reports:         http://github.com/erikd/language-javascript/issues
 License:             BSD3
 License-file:        LICENSE
 Author:              Alan Zimmerman
@@ -13,8 +14,6 @@ Maintainer:          Erik de Castro Lopo <erikd@mega-nerd.com>
 Copyright:           (c) 2010-2015 Alan Zimmerman, 2015 Erik de Castro Lopo
 Category:            Language
 Build-type:          Simple
-homepage:            http://github.com/erikd/language-javascript
-bug-reports:         http://github.com/erikd/language-javascript/issues
 Extra-source-files:  README.md
                      .ghci
                      buildall.sh
@@ -36,6 +35,7 @@ Library
                    -- For the round trip output
                    , blaze-builder    >= 0.2
                    , bytestring       >= 0.9.1
+                   , semigroups       >= 0.16
                    , utf8-string      >= 0.3.7 && < 2
   if impl(ghc >= 7.10)
     build-tools:       happy >= 1.19, alex >= 3.1.4

--- a/src/Language/JavaScript/Pretty/Printer.hs
+++ b/src/Language/JavaScript/Pretty/Printer.hs
@@ -4,6 +4,7 @@ module Language.JavaScript.Pretty.Printer
     , renderToString
     ) where
 
+import Prelude hiding ((<>))
 import Data.Char
 import Data.List
 import Data.Monoid (Monoid, mappend, mempty)


### PR DESCRIPTION
Would be nice if you could add `base < 4.11` constraints to already-released versions on Hackage via the revision mechanism.